### PR TITLE
Add mesa-opencl-icd to recommended packages

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ I'm adding here some extra steps to unsure the users will have amdgpu-pro OpenCL
 
 For better compatibility, install this packages and create a symbolic link:
 
-```sudo apt install opencl-headers ocl-icd-libopencl1 clinfo```
+```sudo apt install opencl-headers ocl-icd-libopencl1 clinfo mesa-opencl-icd```
 
 ```sudo ln -s /usr/lib/x86_64-linux-gnu/libOpenCL.so.1 /usr/lib/libOpenCL.so```
 


### PR DESCRIPTION
Davinci resolve 17 won't work on pop os 21.04/21.10 with RX470 (or other amd gpus, maybe) unless you install mesa-opencl-icd package